### PR TITLE
Dockerfile updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ COPY . .
 RUN npm run build
 
 FROM nginx:latest
-EXPOSE 80
+
 COPY --from=builder /app/build /usr/share/nginx/html
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM node:alpine
-WORKDIR '/app'
-COPY package.json .
+FROM node:alpine as builder
+WORKDIR /app
+# Grabbing package.json and package-lock.json to ensure package versioning
+COPY package*.json .
 RUN npm install
 COPY . .
 RUN npm run build
 
-FROM nginx
+FROM nginx:latest
 EXPOSE 80
-COPY --from=0 /app/build /usr/share/nginx/html
+COPY --from=builder /app/build /usr/share/nginx/html


### PR DESCRIPTION
- Grabbing package-lock.json in addition to package.json to ensure consistent builds
- Named the builder stage for easy visualization
- Reordered the NGINX stage, EXPOSE is typically one of the last tasks. Not an error, just habit.